### PR TITLE
Expose date/time methods and accepts lowercase hex in checksum.

### DIFF
--- a/NMEA0183Messages.cpp
+++ b/NMEA0183Messages.cpp
@@ -301,7 +301,7 @@ bool NMEA0183ParseRMB_nc(const tNMEA0183Msg &NMEA0183Msg, tRMB &RMB) {
 
 //*****************************************************************************
 // $GPRMC,092348.00,A,6035.04228,N,02115.15472,E,0.01,272.61,060815,7.2,E,D*34
-bool NMEA0183ParseRMC_nc(const tNMEA0183Msg &NMEA0183Msg, double &GPSTime, double &Latitude, double &Longitude,
+bool NMEA0183ParseRMC_nc(const tNMEA0183Msg &NMEA0183Msg, double &GPSTime, char &Status, double &Latitude, double &Longitude,
                       double &TrueCOG, double &SOG, unsigned long &DaysSince1970, double &Variation, time_t *DateTime) {
   bool result=( NMEA0183Msg.FieldCount()>=11 );
 
@@ -309,6 +309,7 @@ bool NMEA0183ParseRMC_nc(const tNMEA0183Msg &NMEA0183Msg, double &GPSTime, doubl
     time_t lDT;
 
     GPSTime=NMEA0183GPTimeToSeconds(NMEA0183Msg.Field(0));
+    Status=NMEA0183Msg.Field(1)[0];
     Latitude=LatLonToDouble(NMEA0183Msg.Field(2),NMEA0183Msg.Field(3)[0]);
     Longitude=LatLonToDouble(NMEA0183Msg.Field(4),NMEA0183Msg.Field(5)[0]);
     SOG=atof(NMEA0183Msg.Field(6))*knToms;

--- a/NMEA0183Messages.h
+++ b/NMEA0183Messages.h
@@ -152,6 +152,12 @@ enum tNMEA0183WindReference {
 void NMEA0183AddChecksum(char* msg);
 
 //*****************************************************************************
+double NMEA0183GPTimeToSeconds(const char *data);
+
+//*****************************************************************************
+time_t NMEA0183GPSDateTimetotime_t(const char *dateStr, const char *timeStr);
+
+//*****************************************************************************
 bool NMEA0183SetDBK(tNMEA0183Msg &NMEA0183Msg, double Depth, const char *Src="II");
 
 //*****************************************************************************

--- a/NMEA0183Messages.h
+++ b/NMEA0183Messages.h
@@ -153,6 +153,9 @@ enum tNMEA0183WindReference {
 void NMEA0183AddChecksum(char* msg);
 
 //*****************************************************************************
+double LatLonToDouble(const char *data, const char sign);
+
+//*****************************************************************************
 double NMEA0183GPTimeToSeconds(const char *data);
 
 //*****************************************************************************

--- a/NMEA0183Messages.h
+++ b/NMEA0183Messages.h
@@ -72,6 +72,7 @@ struct tRTE {
 struct tGGA {
 
 	double GPSTime;
+	char status;
 	double latitude;
 	double longitude;
 	int GPSQualityIndicator;
@@ -222,20 +223,20 @@ inline bool NMEA0183ParseRMB(const tNMEA0183Msg &NMEA0183Msg, tRMB &rmb) {
 
 //*****************************************************************************
 // RMC
-bool NMEA0183ParseRMC_nc(const tNMEA0183Msg &NMEA0183Msg, double &GPSTime, double &Latitude, double &Longitude,
+bool NMEA0183ParseRMC_nc(const tNMEA0183Msg &NMEA0183Msg, double &GPSTime, char &Status, double &Latitude, double &Longitude,
                       double &TrueCOG, double &SOG, unsigned long &DaysSince1970, double &Variation, time_t *DateTime=0);
 
-inline bool NMEA0183ParseRMC(const tNMEA0183Msg &NMEA0183Msg, double &GPSTime, double &Latitude, double &Longitude,
+inline bool NMEA0183ParseRMC(const tNMEA0183Msg &NMEA0183Msg, double &GPSTime, char &Status, double &Latitude, double &Longitude,
                       double &TrueCOG, double &SOG, unsigned long &DaysSince1970, double &Variation, time_t *DateTime=0) {
   (void)DateTime;
   return (NMEA0183Msg.IsMessageCode("RMC")
-            ?NMEA0183ParseRMC_nc(NMEA0183Msg, GPSTime, Latitude, Longitude, TrueCOG, SOG, DaysSince1970, Variation, DateTime)
+            ?NMEA0183ParseRMC_nc(NMEA0183Msg, GPSTime, Status, Latitude, Longitude, TrueCOG, SOG, DaysSince1970, Variation, DateTime)
             :false);
 }
 
 inline bool NMEA0183ParseRMC(const tNMEA0183Msg &NMEA0183Msg, tRMC &rmc, time_t *DateTime=0) {
 
-	return NMEA0183ParseRMC(NMEA0183Msg, rmc.GPSTime, rmc.latitude, rmc.longitude, rmc.trueCOG, rmc.SOG, rmc.daysSince1970, rmc.variation, DateTime);
+	return NMEA0183ParseRMC(NMEA0183Msg, rmc.GPSTime, rmc.status, rmc.latitude, rmc.longitude, rmc.trueCOG, rmc.SOG, rmc.daysSince1970, rmc.variation, DateTime);
 }
 
 bool NMEA0183SetRMC(tNMEA0183Msg &NMEA0183Msg, double GPSTime, double Latitude, double Longitude,

--- a/NMEA0183Msg.cpp
+++ b/NMEA0183Msg.cpp
@@ -105,8 +105,8 @@ bool tNMEA0183Msg::SetMessage(const char *buf) {
   if (buf[i]!='*') { Clear(); return false; } // No checksum -> invalid message
   Data[iData]=0; // null termination for previous field
   i++; // Pass '*';
-  csMsg=(buf[i]<=57?buf[i]-48:buf[i]-55)<<4; i++;
-  csMsg|=(buf[i]<=57?buf[i]-48:buf[i]-55);
+  csMsg=(buf[i]<=57?buf[i]-48:(buf[i]<=70?buf[i]-55:buf[i]-87))<<4; i++;
+  csMsg|=(buf[i]<=57?buf[i]-48:(buf[i]<=70?buf[i]-55:buf[i]-87));
 
   if (csMsg==CheckSum) {
     result=true;


### PR DESCRIPTION
Export NMEA0183GPTimeToSeconds and NMEA0183GPSDateTimetotime_t methods.
Enable lowercase hex in NMEA sentence checksum.