### PR TITLE
NMEA0183SetDPT: Limit depth and offset to two decimal places after comma.

### DIFF
--- a/NMEA0183Messages.cpp
+++ b/NMEA0183Messages.cpp
@@ -218,16 +218,16 @@ bool NMEA0183ParseDPT_nc(const tNMEA0183Msg &NMEA0183Msg,  double &DepthBelowTra
 
 bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src) {
   if ( !NMEA0183Msg.Init("DPT",Src) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer, 1, "%.2f")) return false;
-  if ( !NMEA0183Msg.AddDoubleField(Offset, 1, "%.2f") ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer) ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(Offset) ) return false;
   if ( !NMEA0183Msg.AddDoubleField(Range, 1, "%.0f" ) ) return false;  
   return true;
 }
 
 bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src) {
   if ( !NMEA0183Msg.Init("DPT",Src) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer, 1, "%.2f")) return false;
-  if ( !NMEA0183Msg.AddDoubleField(Offset, 1, "%.2f") ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer) ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(Offset) ) return false;
 
   return true;
 }

--- a/NMEA0183Messages.cpp
+++ b/NMEA0183Messages.cpp
@@ -218,16 +218,16 @@ bool NMEA0183ParseDPT_nc(const tNMEA0183Msg &NMEA0183Msg,  double &DepthBelowTra
 
 bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src) {
   if ( !NMEA0183Msg.Init("DPT",Src) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(Offset) ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer, 1, "%.2f")) return false;
+  if ( !NMEA0183Msg.AddDoubleField(Offset, 1, "%.2f") ) return false;
   if ( !NMEA0183Msg.AddDoubleField(Range, 1, "%.0f" ) ) return false;  
   return true;
 }
 
 bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src) {
   if ( !NMEA0183Msg.Init("DPT",Src) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(Offset) ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer, 1, "%.2f")) return false;
+  if ( !NMEA0183Msg.AddDoubleField(Offset, 1, "%.2f") ) return false;
 
   return true;
 }

--- a/NMEA0183Messages.cpp
+++ b/NMEA0183Messages.cpp
@@ -216,7 +216,7 @@ bool NMEA0183ParseDPT_nc(const tNMEA0183Msg &NMEA0183Msg,  double &DepthBelowTra
 	return result;
 }
 
-bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *DepthFormat, const char *Src) {
+bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src, const char *DepthFormat) {
   if ( !NMEA0183Msg.Init("DPT",Src) ) return false;
   if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer, 1, DepthFormat) ) return false;
   if ( !NMEA0183Msg.AddDoubleField(Offset, 1, DepthFormat) ) return false;
@@ -224,7 +224,7 @@ bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, doub
   return true;
 }
 
-bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *DepthFormat, const char *Src) {
+bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src, const char *DepthFormat) {
   if ( !NMEA0183Msg.Init("DPT",Src) ) return false;
   if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer, 1, DepthFormat) ) return false;
   if ( !NMEA0183Msg.AddDoubleField(Offset, 1, DepthFormat) ) return false;

--- a/NMEA0183Messages.cpp
+++ b/NMEA0183Messages.cpp
@@ -216,18 +216,18 @@ bool NMEA0183ParseDPT_nc(const tNMEA0183Msg &NMEA0183Msg,  double &DepthBelowTra
 	return result;
 }
 
-bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src) {
+bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *DepthFormat, const char *Src) {
   if ( !NMEA0183Msg.Init("DPT",Src) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(Offset) ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer, 1, DepthFormat) ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(Offset, 1, DepthFormat) ) return false;
   if ( !NMEA0183Msg.AddDoubleField(Range, 1, "%.0f" ) ) return false;  
   return true;
 }
 
-bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src) {
+bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *DepthFormat, const char *Src) {
   if ( !NMEA0183Msg.Init("DPT",Src) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer) ) return false;
-  if ( !NMEA0183Msg.AddDoubleField(Offset) ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(DepthBelowTransducer, 1, DepthFormat) ) return false;
+  if ( !NMEA0183Msg.AddDoubleField(Offset, 1, DepthFormat) ) return false;
 
   return true;
 }

--- a/NMEA0183Messages.h
+++ b/NMEA0183Messages.h
@@ -256,21 +256,9 @@ inline bool NMEA0183ParseDPT(const tNMEA0183Msg &NMEA0183Msg,  double &DepthBelo
             :false);
 }
 
-bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *DepthFormat, const char *Src);
+bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src="II", const char *DepthFormat=tNMEA0183Msg::DefDoubleFormat);
 
-// Depth and offset are rounded to 1 decimal place after comma.
-inline bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src="II") {
-  return NMEA0183SetDPT(NMEA0183Msg,DepthBelowTransducer,Offset,Range,tNMEA0183Msg::DefDoubleFormat,Src);
-}
-
-// Depth and offset are rounded to 1 decimal place after comma.
-bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *DepthFormat, const char *Src);
-
-inline bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src="II")
-{
-  return NMEA0183SetDPT(NMEA0183Msg,DepthBelowTransducer,Offset,tNMEA0183Msg::DefDoubleFormat,Src);
-}
-
+bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src="II", const char *DepthFormat=tNMEA0183Msg::DefDoubleFormat);
 
 
 //*****************************************************************************

--- a/NMEA0183Messages.h
+++ b/NMEA0183Messages.h
@@ -256,8 +256,10 @@ inline bool NMEA0183ParseDPT(const tNMEA0183Msg &NMEA0183Msg,  double &DepthBelo
             :false);
 }
 
+// The depth and offset are limited to two decimal places using the rounding rules of printf.
 bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src="II");
 
+// The depth and offset are limited to two decimal places using the rounding rules of printf.
 bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src="II");
 
 

--- a/NMEA0183Messages.h
+++ b/NMEA0183Messages.h
@@ -256,10 +256,8 @@ inline bool NMEA0183ParseDPT(const tNMEA0183Msg &NMEA0183Msg,  double &DepthBelo
             :false);
 }
 
-// The depth and offset are limited to two decimal places using the rounding rules of printf.
 bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src="II");
 
-// The depth and offset are limited to two decimal places using the rounding rules of printf.
 bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src="II");
 
 

--- a/NMEA0183Messages.h
+++ b/NMEA0183Messages.h
@@ -256,9 +256,21 @@ inline bool NMEA0183ParseDPT(const tNMEA0183Msg &NMEA0183Msg,  double &DepthBelo
             :false);
 }
 
-bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src="II");
+bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *DepthFormat, const char *Src);
 
-bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src="II");
+// Depth and offset are rounded to 1 decimal place after comma.
+inline bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, double Range, const char *Src="II") {
+  return NMEA0183SetDPT(NMEA0183Msg,DepthBelowTransducer,Offset,Range,tNMEA0183Msg::DefDoubleFormat,Src);
+}
+
+// Depth and offset are rounded to 1 decimal place after comma.
+bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *DepthFormat, const char *Src);
+
+inline bool NMEA0183SetDPT(tNMEA0183Msg &NMEA0183Msg, double DepthBelowTransducer, double Offset, const char *Src="II")
+{
+  return NMEA0183SetDPT(NMEA0183Msg,DepthBelowTransducer,Offset,tNMEA0183Msg::DefDoubleFormat,Src);
+}
+
 
 
 //*****************************************************************************


### PR DESCRIPTION
Rationale: this is useful in cases when the depth is computed and can have many places after comma. To the best of my knowledge, in nautical applications centimeter precision is sufficient.