### PR TITLE
NMEA0183Messages.h: Changed the include style for NMEA0183Msg.h to quotes.

### DIFF
--- a/NMEA0183Messages.h
+++ b/NMEA0183Messages.h
@@ -26,7 +26,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define _tNMEA0183_MESSAGES_H_
 #include <stdio.h>
 #include <time.h>
-#include <NMEA0183Msg.h>
+#include "NMEA0183Msg.h"
 
 #ifndef Arduino
 typedef uint8_t byte;


### PR DESCRIPTION
This permits the compiler to find the file when it is in the same directory.
Rationale: This way one can have NMEA0183 in a subdirectory and one can do #include <NMEA0183/NMEA0183Messages.h>
and the compiler will do the right thing and find the NMEA0183Msg.h instead of complaining.