### PR TITLE
Added first unit tests for SetDPT/ParseDPT and a CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,48 @@
+# CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2015-2022 Timo Lappalainen, Kave Oy, www.kave.fi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+# OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+cmake_minimum_required(VERSION 3.0)
+project(NMEA0183)
+
+add_compile_options(
+  -Wall
+  -Werror
+  -g
+)
+
+# Our library
+file(GLOB NMEA0183_SOURCES *.cpp)
+add_library(nmea0183 STATIC ${NMEA0183_SOURCES})
+
+
+# Unit tests
+find_package(Catch2 REQUIRED)
+
+file(GLOB TEST0183_SOURCES test/*.cpp)
+add_executable(test0183 ${TEST0183_SOURCES})
+target_include_directories(test0183 PUBLIC .)
+target_link_libraries(test0183 nmea0183 Catch2::Catch2)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(test0183)

--- a/test/MessagesTest.cpp
+++ b/test/MessagesTest.cpp
@@ -1,0 +1,65 @@
+/*
+NMEA0183Messages.cpp
+
+The MIT License
+
+Copyright (c) 2015-2022 Timo Lappalainen, Kave Oy, www.kave.fi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+// \brief Tests for functions in NMEA0183Messages.h.
+
+#define CATCH_CONFIG_MAIN
+#include <functional> // std::function
+
+#include <string.h>
+#include <catch2/catch.hpp>
+#include <NMEA0183Messages.h>
+
+// Plan is simple:
+// 1. Convert the string nmea0183 to a src.
+// 2. Invoke parse_and_set to parse src and set the dst.
+// 3. Convert dst to string again and compare with the original.
+void test_nmea0183_message(const char* nmea0183, std::function<void(tNMEA0183Msg&, tNMEA0183Msg&)> parse_and_set)
+{
+  char result[100];
+  tNMEA0183Msg src, dst;
+
+  CHECK(src.SetMessage(nmea0183));
+  parse_and_set(src, dst);
+  CHECK(dst.GetMessage(result, sizeof(result)));
+  CHECK(strcmp(result, nmea0183) == 0);
+}
+
+TEST_CASE("DPT before NMEA0183 v3.0")
+{
+  test_nmea0183_message("$IIDPT,10.5,0.9*7D", [](tNMEA0183Msg& src, tNMEA0183Msg& dst) {
+    double depth, offset;
+    CHECK(NMEA0183ParseDPT(src, depth, offset));
+    CHECK(NMEA0183SetDPT(dst, depth, offset));
+  });
+}
+
+TEST_CASE("DPT after NMEA0183 v3.0")
+{
+  test_nmea0183_message("$IIDPT,10.5,0.9,100*60", [](tNMEA0183Msg& src, tNMEA0183Msg& dst) {
+    double depth, offset, range;
+    CHECK(NMEA0183ParseDPT(src, depth, offset, range));
+    CHECK(NMEA0183SetDPT(dst, depth, offset, range));
+  });
+}

--- a/test/millis.cpp
+++ b/test/millis.cpp
@@ -1,0 +1,34 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017 Thomas Sarlandie thomas@sarlandie.net
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#include <stdint.h>
+
+extern "C" {
+
+// So that millis() work
+uint32_t millis() {
+  return 42;
+}
+
+}


### PR DESCRIPTION
First unit tests.

The file "millis.cpp" was directly lifted from NMEA2000, thus, the different copyright message.