### PR TITLE
Added a testcase for the SetZDA; improved error message

### DIFF
--- a/test/MessagesTest.cpp
+++ b/test/MessagesTest.cpp
@@ -63,3 +63,13 @@ TEST_CASE("DPT after NMEA0183 v3.0")
     CHECK(NMEA0183SetDPT(dst, depth, offset, range));
   });
 }
+
+TEST_CASE("ZDA")
+{
+  test_nmea0183_message("$GPZDA,160012.71,11,03,2004,-1,00*7D", [](tNMEA0183Msg& src, tNMEA0183Msg& dst) {
+    double GPSTime;
+    int GPSDay, GPSMonth, GPSYear, LZD, LZMD;
+    CHECK(NMEA0183ParseZDA(src, GPSTime, GPSDay, GPSMonth, GPSYear, LZD, LZMD));
+    CHECK(NMEA0183SetZDA(dst, GPSTime, GPSDay, GPSMonth, GPSYear, LZD, LZMD));
+  });
+}

--- a/test/MessagesTest.cpp
+++ b/test/MessagesTest.cpp
@@ -43,7 +43,7 @@ void test_nmea0183_message(const char* nmea0183, std::function<void(tNMEA0183Msg
   CHECK(src.SetMessage(nmea0183));
   parse_and_set(src, dst);
   CHECK(dst.GetMessage(result, sizeof(result)));
-  CHECK(strcmp(result, nmea0183) == 0);
+  CHECK_THAT(result, Catch::Matchers::Equals(nmea0183));
 }
 
 TEST_CASE("DPT before NMEA0183 v3.0")


### PR DESCRIPTION
The testcase covers only one of the SetZDA overloads.

The error message now includes both the original NMEA0183 string and the end result, which should be equal. Failures are reported in the following manner:

ctest --output-on-failure
....
MessagesTest.cpp:46: FAILED:
  CHECK_THAT( result, Catch::Matchers::Equals(nmea0183) )
with expansion:
  "$GPZDA,160012.71,11,03,2005,-1,00*7C" equals: "$GPZDA,160012.71,11,03,2004,-
  1,00*7D"
....
